### PR TITLE
Propagate errors

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -6,8 +6,14 @@ import (
 	"strings"
 )
 
+type Error struct {
+	Message    string `json:"message,omitempty"`
+	StatusCode int    `json:"status_code,omitempty"`
+}
+
 // Address represents an address stored in the Lob's system.
 type Address struct {
+	Error          *Error            `json:"error"`
 	AddressCity    *string           `json:"address_city"`
 	AddressCountry *string           `json:"address_country"`
 	AddressLine1   string            `json:"address_line1"`
@@ -31,7 +37,7 @@ type Address struct {
 func (lob *lob) CreateAddress(address *Address) (*Address, error) {
 	resp := new(Address)
 	if err := lob.post("addresses", json2form(*address), resp); err != nil {
-		return nil, err
+		return resp, err
 	}
 	return resp, nil
 }
@@ -40,7 +46,7 @@ func (lob *lob) CreateAddress(address *Address) (*Address, error) {
 func (lob *lob) GetAddress(id string) (*Address, error) {
 	resp := new(Address)
 	if err := lob.get("addresses/"+id, nil, resp); err != nil {
-		return nil, err
+		return resp, err
 	}
 	return resp, nil
 }

--- a/bank_accounts.go
+++ b/bank_accounts.go
@@ -4,6 +4,7 @@ import "strconv"
 
 // BankAccount represents a bank account in lob's system.
 type BankAccount struct {
+	Error         *Error            `json:"error"`
 	AccountNumber string            `json:"account_number"`
 	BankName      string            `json:"bank_name"`
 	DateCreated   string            `json:"date_created"`

--- a/checks.go
+++ b/checks.go
@@ -23,6 +23,7 @@ type Check struct {
 	Logo                 *string             `json:"logo"`
 	MailType             *string             `json:"mail_type"`
 	Memo                 string              `json:"memo"`
+	Message              *string             `json:"message"`
 	Metadata             map[string]string   `json:"metadata"`
 	Name                 string              `json:"name"`
 	Object               string              `json:"object"`

--- a/checks.go
+++ b/checks.go
@@ -7,6 +7,7 @@ import (
 
 // Check represents a printed check in Lob's system.
 type Check struct {
+	Error                Error               `json:"error"`
 	Amount               float64             `json:"amount"`
 	BankAccount          *BankAccount        `json:"bank_account"`
 	CheckBottom          *string             `json:"check_bottom"`
@@ -22,7 +23,6 @@ type Check struct {
 	Logo                 *string             `json:"logo"`
 	MailType             *string             `json:"mail_type"`
 	Memo                 string              `json:"memo"`
-	Message              *string             `json:"message"`
 	Metadata             map[string]string   `json:"metadata"`
 	Name                 string              `json:"name"`
 	Object               string              `json:"object"`
@@ -68,7 +68,7 @@ type CreateCheckRequest struct {
 func (lob *lob) CreateCheck(req *CreateCheckRequest) (*Check, error) {
 	resp := new(Check)
 	if err := lob.post("checks/", json2form(*req), resp); err != nil {
-		return nil, err
+		return resp, err
 	}
 	return resp, nil
 }
@@ -82,7 +82,7 @@ type CancelCheckResponse struct {
 func (lob *lob) GetCheck(id string) (*Check, error) {
 	resp := new(Check)
 	if err := lob.get("checks/"+id, nil, resp); err != nil {
-		return nil, err
+		return resp, err
 	}
 	return resp, nil
 }
@@ -90,7 +90,7 @@ func (lob *lob) GetCheck(id string) (*Check, error) {
 func (lob *lob) CancelCheck(id string) (*CancelCheckResponse, error) {
 	resp := new(CancelCheckResponse)
 	if err := lob.delete("checks/"+id, &resp); err != nil {
-		return nil, err
+		return resp, err
 	}
 	return resp, nil
 }

--- a/lob.go
+++ b/lob.go
@@ -126,6 +126,8 @@ func json2form(v interface{}) map[string]string {
 			for mapkey, mapvalue := range x {
 				params[name+"["+mapkey+"]"] = mapvalue
 			}
+		case *Error:
+			// do not turn into form values. This is for the return response only
 		default:
 			// ignore
 			panic(fmt.Errorf("Unknown field type: " + value.Field(i).Type().String()))

--- a/lob_test.go
+++ b/lob_test.go
@@ -54,6 +54,29 @@ func TestAddresses(t *testing.T) {
 		t.Errorf("Error deleting address: %s", err.Error())
 	}
 }
+func TestAddressError(t *testing.T) {
+	lob := NewLob(BaseAPI, testAPIKey, testUserAgent)
+
+	address, err := lob.CreateAddress(&Address{
+		Name:           nullString("Name that is way too long to be printed on the check so that it will error."),
+		Email:          nullString("lobtest@example.com"),
+		Phone:          nullString("5555555555"),
+		AddressLine1:   "1005 W Burnside St", // Powell's City of Books, the best book store in the world.
+		AddressCity:    nullString("Portland"),
+		AddressState:   nullString("OR"),
+		AddressZip:     nullString("97209"),
+		AddressCountry: nullString("US"),
+	})
+	if err == nil {
+		t.Error("error should not have been nil")
+	}
+	if address.Error.Message == "" {
+		t.Error("Expected human readable error message")
+	}
+	if address.Error.StatusCode != 422 {
+		t.Error("Expected status code to be 422")
+	}
+}
 
 func TestBankAccounts(t *testing.T) {
 	lob := NewLob(BaseAPI, testAPIKey, testUserAgent)

--- a/test_lob.go
+++ b/test_lob.go
@@ -9,6 +9,8 @@ import (
 	"github.com/pborman/uuid"
 )
 
+var Non200Error = errors.New("Non-200 Status code returned")
+
 type fakeLob struct {
 	checks       map[string]*Check
 	addresses    map[string]*Address
@@ -88,6 +90,26 @@ func (t *fakeLob) ListChecks(count, offset int) (*ListChecksResponse, error) {
 // Addresses
 
 func (t *fakeLob) CreateAddress(address *Address) (*Address, error) {
+	var message string
+	var status int
+	if address.Name != nil && len(*address.Name) > 40 {
+		message = "name length must be less than or equal to 40 characters long"
+		status = 422
+		address.Error = &Error{
+			Message:    message,
+			StatusCode: status,
+		}
+		return address, Non200Error
+	}
+	if len(address.AddressLine1) > 200 {
+		message = "address_line1 length must be less than or equal to 200 characters long"
+		status = 422
+		address.Error = &Error{
+			Message:    message,
+			StatusCode: status,
+		}
+		return address, Non200Error
+	}
 	if address.ID == "" {
 		address.ID = uuid.New()
 	}


### PR DESCRIPTION
## Summary

This PR allows the error object from lob, standardized to 

```
{
"error":{"message":"some human readable message","status_code":422}
}
```
to be unmarshalled into the response struct so that downstream clients can make a decision based on the error