### PR TITLE
Add Support for Letters

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -158,6 +158,10 @@ type USAddressDeliverabilityAnalysis struct {
 	SuiteReturnCode string   `json:"suite_return_code"`
 }
 
+// with special codes you can get a proper response back in test mode; this magic secondary line means we didn't
+// request it with a special code so fallback to the old behavior
+const testFillInLine2Required = "See Https://www.lob.com/docs#us-verification-test-environment For More Info"
+
 // VerifyUSAddress verifies the given US address and returns the validation results.
 func (lob *lob) VerifyUSAddress(address *Address) (*USAddressVerificationResponse, error) {
 	req := USAddressVerificationRequest{
@@ -174,7 +178,7 @@ func (lob *lob) VerifyUSAddress(address *Address) (*USAddressVerificationRespons
 	}
 
 	// in test, fill in components
-	if strings.HasPrefix(lob.APIKey, "test") {
+	if strings.HasPrefix(lob.APIKey, "test") && resp.SecondaryLine != testFillInLine2Required {
 		streetSplit := strings.Split(address.AddressLine1, " ")
 		if len(streetSplit) > 2 {
 			resp.Components.PrimaryNumber = streetSplit[0]
@@ -224,7 +228,7 @@ func (lob *lob) VerifyUSAddressWithCasing(address *Address, casing AddressVerifi
 	}
 
 	// in test, fill in components
-	if strings.HasPrefix(lob.APIKey, "test") {
+	if strings.HasPrefix(lob.APIKey, "test") && resp.SecondaryLine != testFillInLine2Required {
 		streetSplit := strings.Split(address.AddressLine1, " ")
 		if len(streetSplit) > 2 {
 			resp.Components.PrimaryNumber = streetSplit[0]

--- a/addresses.go
+++ b/addresses.go
@@ -178,7 +178,7 @@ func (lob *lob) VerifyUSAddress(address *Address) (*USAddressVerificationRespons
 	}
 
 	// in test, fill in components
-	if strings.HasPrefix(lob.APIKey, "test") && resp.SecondaryLine != testFillInLine2Required {
+	if strings.HasPrefix(lob.APIKey, "test") && resp.SecondaryLine == testFillInLine2Required {
 		streetSplit := strings.Split(address.AddressLine1, " ")
 		if len(streetSplit) > 2 {
 			resp.Components.PrimaryNumber = streetSplit[0]
@@ -228,7 +228,7 @@ func (lob *lob) VerifyUSAddressWithCasing(address *Address, casing AddressVerifi
 	}
 
 	// in test, fill in components
-	if strings.HasPrefix(lob.APIKey, "test") && resp.SecondaryLine != testFillInLine2Required {
+	if strings.HasPrefix(lob.APIKey, "test") && resp.SecondaryLine == testFillInLine2Required {
 		streetSplit := strings.Split(address.AddressLine1, " ")
 		if len(streetSplit) > 2 {
 			resp.Components.PrimaryNumber = streetSplit[0]

--- a/addresses.go
+++ b/addresses.go
@@ -106,18 +106,31 @@ type USAddressVerificationRequest struct {
 
 // USAddressVerificationResponse gives the response from attempting to verify a US address.
 type USAddressVerificationResponse struct {
-	Id                     string                          `json:"id"`
-	Recipient              string                          `json:"recipient"`
-	PrimaryLine            string                          `json:"primary_line"`
-	SecondaryLine          string                          `json:"secondary_line"`
-	Urbanization           string                          `json:"urbanization,omitempty"`
-	LastLine               string                          `json:"last_line"`
-	Deliverability         string                          `json:"deliverability"`
-	Components             USAddressComponents             `json:"components"`
-	DeliverabilityAnalysis USAddressDeliverabilityAnalysis `json:"deliverability_analysis"`
-	Object                 string                          `json:"object"`
+	Id                     string                              `json:"id"`
+	Recipient              string                              `json:"recipient"`
+	PrimaryLine            string                              `json:"primary_line"`
+	SecondaryLine          string                              `json:"secondary_line"`
+	Urbanization           string                              `json:"urbanization,omitempty"`
+	LastLine               string                              `json:"last_line"`
+	Deliverability         USAddressVerificationDeliverability `json:"deliverability"`
+	Components             USAddressComponents                 `json:"components"`
+	DeliverabilityAnalysis USAddressDeliverabilityAnalysis     `json:"deliverability_analysis"`
+	Object                 string                              `json:"object"`
 }
 
+//USAddressVerificationDeliverability is the type for the deliverability of an address verified
+type USAddressVerificationDeliverability string
+
+//list of USAddressVerificationDeliverability values
+var (
+	USAddressVerificationDeliverabilityDeliverable     USAddressVerificationDeliverability = "deliverable"
+	USAddressVerificationDeliverabilityUnnecessaryUnit USAddressVerificationDeliverability = "deliverable_unnecessary_unit"
+	USAddressVerificationDeliverabilityIncorrectUnit   USAddressVerificationDeliverability = "deliverable_incorrect_unit"
+	USAddressVerificationDeliverabilitydMissingUnit    USAddressVerificationDeliverability = "deliverable_missing_unit"
+	USAddressVerificationDeliverabilityUndeliverable   USAddressVerificationDeliverability = "undeliverable"
+)
+
+//USAddressComponents are the components which make up a US address
 type USAddressComponents struct {
 	PrimaryNumber             string  `json:"primary_number"`
 	StreetPredirection        string  `json:"street_predirection"`

--- a/checks.go
+++ b/checks.go
@@ -33,36 +33,21 @@ type Check struct {
 	URL                  string              `json:"url"`
 }
 
-// Tracking provides information on shipment tracking for a check.
-type Tracking struct {
-	Carrier        string        `json:"carrier"`
-	Events         []interface{} `json:"events"`
-	ID             string        `json:"id"`
-	Link           *string       `json:"link"`
-	Object         string        `json:"object"`
-	TrackingNumber string        `json:"tracking_number"`
-}
-
-// Mail types that lob supports.
-const (
-	MailTypeUspsFirstClass = "usps_first_class"
-	MailTypeUpsNextDayAir  = "ups_next_day_air"
-)
-
 // CreateCheckRequest specifies options for creating a check.
 type CreateCheckRequest struct {
-	Amount        float64           `json:"amount"`
-	BankAccountID string            `json:"bank_account"`
-	CheckBottom   *string           `json:"check_bottom"` // 400 chars, at bottom (cannot use with message)
-	CheckNumber   *string           `json:"check_number"`
-	Data          map[string]string `json:"data"`
-	Description   *string           `json:"description"`
-	FromAddressID string            `json:"from"`
-	Logo          *string           `json:"logo"` // url or multiform. Square, RGB / CMYK, >= 100x100, transparent bg, PNG or JPEG, and will be grayscaled
-	MailType      *string           `json:"mail_type"`
-	Memo          *string           `json:"memo"`    // 40 chars in memo line
-	Message       *string           `json:"message"` // 400 chars, at top (cannot use with check_bottom)
-	ToAddressID   string            `json:"to"`
+	Amount         float64           `json:"amount"`
+	BankAccountID  string            `json:"bank_account"`
+	CheckBottom    *string           `json:"check_bottom"` // 400 chars, at bottom (cannot use with message)
+	CheckNumber    *string           `json:"check_number"`
+	Data           map[string]string `json:"data"`
+	Description    *string           `json:"description"`
+	FromAddressID  string            `json:"from"`
+	Logo           *string           `json:"logo"` // url or multiform. Square, RGB / CMYK, >= 100x100, transparent bg, PNG or JPEG, and will be grayscaled
+	MailType       *string           `json:"mail_type"`
+	Memo           *string           `json:"memo"`    // 40 chars in memo line
+	Message        *string           `json:"message"` // 400 chars, at top (cannot use with check_bottom)
+	ToAddressID    string            `json:"to"`
+	BillingGroupID *string           `json:"billing_group_id"`
 }
 
 // CreateCheck requests for a new check to be printed and mailed.
@@ -113,7 +98,7 @@ func (lob *lob) ListChecks(count int) (*ListChecksResponse, error) {
 
 	resp := new(ListChecksResponse)
 	if err := lob.get("checks", map[string]string{
-		"limit":  strconv.Itoa(count),
+		"limit": strconv.Itoa(count),
 	}, resp); err != nil {
 		return nil, err
 	}

--- a/letters.go
+++ b/letters.go
@@ -10,6 +10,7 @@ import (
 // Letter represents a letter in lob's system
 type Letter struct {
 	Error                *Error                 `json:"error"`
+	ID                   string                 `json:"id"`
 	Description          *string                `json:"description"`
 	Metadata             map[string]string      `json:"metadata"`
 	To                   *Address               `json:"to"`

--- a/letters.go
+++ b/letters.go
@@ -30,7 +30,7 @@ type Letter struct {
 	TrackingNumber       *string                `json:"tracking_number"`
 	TrackingEvents       []TrackingEvent        `json:"tracking_events"`
 	Thumbnails           []LetterThumbnail      `json:"thumbnails"`
-	ExpectedDeliveryDate time.Time              `json:"expected_delivery_date"`
+	ExpectedDeliveryDate string                 `json:"expected_delivery_date"`
 	DateCreated          time.Time              `json:"date_created"`
 	DateModified         time.Time              `json:"date_modified"`
 	SendDate             time.Time              `json:"send_date"`

--- a/letters.go
+++ b/letters.go
@@ -1,0 +1,162 @@
+package lob
+
+import (
+	"strconv"
+	"time"
+)
+
+//#region model definition
+
+// Letter represents a letter in lob's system
+type Letter struct {
+	Error                *Error                 `json:"error"`
+	Description          *string                `json:"description"`
+	Metadata             map[string]string      `json:"metadata"`
+	To                   *Address               `json:"to"`
+	From                 *Address               `json:"from"`
+	Color                bool                   `json:"color"`
+	DoubleSided          bool                   `json:"double_sided"`
+	AddressPlacement     LetterAddressPlacement `json:"address_placement"`
+	ReturnEnvelope       bool                   `json:"return_envelope"`
+	PerforatedPage       *uint64                `json:"perforated_page"`
+	CustomEnvelope       *CustomEnvelope        `json:"custom_envelope"`
+	ExtraService         *LetterExtraService    `json:"extra_service"`
+	MailType             *string                `json:"mail_type"` //MailTypeUspsFirstClass or MailTypeUspsStandard
+	URL                  string                 `json:"url"`
+	MergeVariables       map[string]string      `json:"merge_variables"`
+	TemplateID           *string                `json:"template_id"`
+	TemplateVersionID    *string                `json:"template_version_id"`
+	Carrier              string                 `json:"carrier"` //value is USPS
+	TrackingNumber       *string                `json:"tracking_number"`
+	TrackingEvents       []TrackingEvent        `json:"tracking_events"`
+	Thumbnails           []LetterThumbnail      `json:"thumbnails"`
+	ExpectedDeliveryDate time.Time              `json:"expected_delivery_date"`
+	DateCreated          time.Time              `json:"date_created"`
+	DateModified         time.Time              `json:"date_modified"`
+	SendDate             time.Time              `json:"send_date"`
+	Deleted              bool                   `json:"deleted"`
+	Object               string                 `json:"object"` //value will always be letter
+}
+
+//CreateLetterRequest is the object for creating a new letter
+type CreateLetterRequest struct {
+	Description      *string                `json:"description"` //must be no longer than 255 characters
+	To               Address                `json:"to"`          //if you need the id, simply do lob.Address{ID: "id-here"}
+	From             Address                `json:"from"`        //if you need the id, simply do lob.Address{ID: "id-here"}
+	BillingGroupID   *string                `json:"billing_group_id"`
+	SendDate         *time.Time             `json:"send_date"`
+	Color            bool                   `json:"color"`
+	File             string                 `json:"file"` //please see lob's create letter documentation: https://lob.com/docs#letters_create
+	DoubleSided      bool                   `json:"double_sided"`
+	AddressPlacement LetterAddressPlacement `json:"address_placement"`
+	MailType         *string                `json:"mail_type"` //MailTypeUspsFirstClass or MailTypeUspsStandard
+	ExtraService     *LetterExtraService    `json:"extra_service"`
+	ReturnEnvelope   bool                   `json:"return_envelope"`
+	PerforatedPage   *uint64                `json:"perforated_page"`
+	CustomEnvelope   *CustomEnvelope        `json:"custom_envelope"`
+	MergeVariables   map[string]string      `json:"merge_variables"`
+	Metadata         map[string]string      `json:"metadata"`
+}
+
+//LetterAddressPlacement represents where the address should be placed on the letter
+type LetterAddressPlacement string
+
+var (
+	//LetterAddressPlacementTopFirstPage is for being printed at the top of the first page
+	LetterAddressPlacementTopFirstPage LetterAddressPlacement = "top_first_page"
+	//LetterAddressPlacementInsertBlankPage is for inserting a blank page (does cost extra)
+	LetterAddressPlacementInsertBlankPage LetterAddressPlacement = "insert_blank_page"
+)
+
+// CustomEnvelope represents a custom envelope in lob's system
+type CustomEnvelope struct {
+	ID     string `json:"id"`
+	URL    string `json:"url"`
+	Object string `json:"object"` //value should always be "envelope"
+}
+
+//LetterExtraService represents the type of extra service requested
+type LetterExtraService string
+
+var (
+	//LetterExtraServiceCertified is for certified mail
+	LetterExtraServiceCertified LetterExtraService = "certified"
+	//LetterExtraServiceCertifiedReturnReceipt is for certified mail with return receipt
+	LetterExtraServiceCertifiedReturnReceipt LetterExtraService = "certified_return_receipt"
+	//LetterExtraServiceRegistered is for registered mail
+	LetterExtraServiceRegistered LetterExtraService = "registered"
+)
+
+//LetterThumbnail represents the thumbnails of the generated letter
+type LetterThumbnail struct {
+	Small  string `json:"small"`
+	Medium string `json:"medium"`
+	Large  string `json:"large"`
+}
+
+//ListLettersResponse details all of the letters we've ever mailed and printed
+type ListLettersResponse struct {
+	Data        []Letter `json:"data"`
+	Object      string   `json:"object"` //value will always be letter
+	NextURL     string   `json:"next_url"`
+	PreviousURL string   `json:"previous_url"`
+	Count       int      `json:"count"`
+}
+
+//CancelLetterResponse is the response returned when deleting a letter
+type CancelLetterResponse struct {
+	ID      string `json:"id"`
+	Deleted bool   `json:"deleted"`
+}
+
+//#endregion model definition
+
+// CreateLetter requests for a new letter to be printed and mailed.
+func (lob *lob) CreateLetter(req CreateLetterRequest) (*Letter, error) {
+	resp := new(Letter)
+
+	if err := lob.post("letters", json2form(req), resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// GetLetter gets information about a particulr letter.
+func (lob *lob) GetLetter(id string) (*Letter, error) {
+	resp := new(Letter)
+
+	if err := lob.get("letters/"+id, nil, resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// ListLetters retrieves information on all letters we've ever made, in reverse chrono order
+func (lob *lob) ListLetters(count int) (*ListLettersResponse, error) {
+	if count <= 0 {
+		count = 10
+	}
+
+	query := map[string]string{
+		"limit": strconv.Itoa(count),
+	}
+
+	resp := new(ListLettersResponse)
+	if err := lob.get("letters", query, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// CancelLetter prevents a letter from being sent, if the send date has yet to pass
+func (lob *lob) CancelLetter(id string) (*CancelLetterResponse, error) {
+	resp := new(CancelLetterResponse)
+	if err := lob.delete("letters/"+id, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}

--- a/lob.go
+++ b/lob.go
@@ -66,7 +66,7 @@ type lob struct {
 // Base URL and API version for Lob.
 const (
 	BaseAPI    = "https://api.lob.com/v1/"
-	APIVersion = "2019-06-01"
+	APIVersion = "2020-02-11"
 )
 
 // NewLob creates an object that can be used to connect to the lob.com API.

--- a/lob.go
+++ b/lob.go
@@ -48,6 +48,11 @@ type Lob interface {
 	CreateBankAccount(*CreateBankAccountRequest) (*BankAccount, error)
 	GetBankAccount(string) (*BankAccount, error)
 	ListBankAccounts(int) (*ListBankAccountsResponse, error)
+	// Letters
+	CreateLetter(CreateLetterRequest) (*Letter, error)
+	GetLetter(string) (*Letter, error)
+	ListLetters(int) (*ListLettersResponse, error)
+	CancelLetter(string) (*CancelLetterResponse, error)
 }
 
 // Lob represents information on how to connect to the lob.com API.

--- a/lob.go
+++ b/lob.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/op/go-logging"
 )
@@ -118,6 +119,8 @@ func json2form(v interface{}) map[string]string {
 			if x != nil {
 				params[name] = fmt.Sprintf("%v", *x)
 			}
+		case bool:
+			params[name] = fmt.Sprintf("%v", x)
 		case int64:
 			if x != 0 {
 				params[name] = strconv.FormatInt(x, 10)
@@ -125,7 +128,9 @@ func json2form(v interface{}) map[string]string {
 		case float64:
 			params[name] = fmt.Sprintf("%.2f", x)
 		case *uint64:
-			params[name] = fmt.Sprintf("%d", *x)
+			if x != nil {
+				params[name] = fmt.Sprintf("%d", *x)
+			}
 		case []string:
 			if len(x) > 0 {
 				params[name] = strings.Join(x, " ")
@@ -133,6 +138,26 @@ func json2form(v interface{}) map[string]string {
 		case map[string]string:
 			for mapkey, mapvalue := range x {
 				params[name+"["+mapkey+"]"] = mapvalue
+			}
+		case *time.Time:
+			if x != nil {
+				params[name] = x.Format(time.RFC3339)
+			}
+		case Address:
+			for k, v := range json2form(x) {
+				params[name+"["+k+"]"] = v
+			}
+		case LetterAddressPlacement:
+			params[name] = fmt.Sprintf("%s", x)
+		case *LetterExtraService:
+			if x != nil {
+				params[name] = fmt.Sprintf("%s", *x)
+			}
+		case *CustomEnvelope:
+			if x != nil {
+				for k, v := range json2form(x) {
+					params[name+"["+k+"]"] = v
+				}
 			}
 		case *Error:
 			// do not turn into form values. This is for the return response only

--- a/lob.go
+++ b/lob.go
@@ -41,6 +41,7 @@ type Lob interface {
 	DeleteAddress(string) error
 	ListAddresses(int) (*ListAddressesResponse, error)
 	VerifyUSAddress(*Address) (*USAddressVerificationResponse, error)
+	VerifyUSAddressWithCasing(*Address, AddressVerificationRequestCasing) (*USAddressVerificationResponse, error)
 	// NamedObject
 	GetStates() (*NamedObjectList, error)
 	GetCountries() (*NamedObjectList, error)
@@ -123,6 +124,8 @@ func json2form(v interface{}) map[string]string {
 			}
 		case float64:
 			params[name] = fmt.Sprintf("%.2f", x)
+		case *uint64:
+			params[name] = fmt.Sprintf("%d", *x)
 		case []string:
 			if len(x) > 0 {
 				params[name] = strings.Join(x, " ")

--- a/mail.go
+++ b/mail.go
@@ -1,0 +1,69 @@
+package lob
+
+import (
+	"time"
+)
+
+// Mail types that lob supports.
+const (
+	MailTypeUspsStandard   = "usps_standard"
+	MailTypeUspsFirstClass = "usps_first_class"
+	MailTypeUpsNextDayAir  = "ups_next_day_air"
+)
+
+// Tracking provides information on shipment tracking for a check.
+type Tracking struct {
+	Carrier        string          `json:"carrier"`
+	Events         []TrackingEvent `json:"events"`
+	ID             string          `json:"id"`
+	Link           *string         `json:"link"`
+	Object         string          `json:"object"`
+	TrackingNumber string          `json:"tracking_number"`
+}
+
+//TrackingEvent represents an event from the tracking
+type TrackingEvent struct {
+	ID           string                `json:"id"`
+	Type         TrackingEventType     `json:"type"`
+	Name         TrackingEventName     `json:"name"`
+	Details      *TrackingEventDetails `json:"details"`
+	Location     *string               `json:"location"`
+	Time         time.Time             `json:"time"`
+	DateCreated  time.Time             `json:"date_created"`
+	DateModified time.Time             `json:"date_modified"`
+	Object       string                `json:"object"` //value will be tracking_event
+}
+
+//TrackingEventType indicates the type of event
+type TrackingEventType string
+
+var (
+	//TrackingEventTypeCertified is for certified mail; has the details property on the event
+	TrackingEventTypeCertified TrackingEventType = "certified"
+	//TrackingEventTypeNormal is for normal non-certified postcards, letters, and checks
+	TrackingEventTypeNormal TrackingEventType = "normal"
+)
+
+//TrackingEventName is a special type for event names
+type TrackingEventName string
+
+//list of event names
+var (
+	TrackingEventNameMailed               TrackingEventName = "Mailed"
+	TrackingEventNameInTransit            TrackingEventName = "In Transit"
+	TrackingEventNameInLocalArea          TrackingEventName = "In Local Area"
+	TrackingEventNameProcessedForDelivery TrackingEventName = "Processed for Delivery"
+	TrackingEventNameReRouted             TrackingEventName = "Re-Routed"
+	TrackingEventNameReturnedToSender     TrackingEventName = "Returned to Sender"
+	TrackingEventNamePickupAvailable      TrackingEventName = "Pickup Available"
+	TrackingEventNameDelivered            TrackingEventName = "Delivered"
+	TrackingEventNameIssue                TrackingEventName = "Issue"
+)
+
+//TrackingEventDetails is for the details of a tracking event, only happens for certified mail
+type TrackingEventDetails struct {
+	Event          string `json:"event"`
+	Description    string `json:"description"`
+	Notes          string `json:"notes"`
+	ActionRequired bool   `json:"action_required"`
+}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,16 @@
+package lob
+
+//String is a helper function for creating a pointer string
+func String(val string) *string {
+	return &val
+}
+
+//Bool is a helper function for creating a pointer boolean
+func Bool(val bool) *bool {
+	return &val
+}
+
+//Uint64 is a helper function for creating a pointer uint64
+func Uint64(val uint64) *uint64 {
+	return &val
+}

--- a/webhook.go
+++ b/webhook.go
@@ -1,0 +1,70 @@
+package lob
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"time"
+)
+
+// Errors returned by the webbook parsing
+var (
+	ErrInvalidHeader    = errors.New("webhook has invalid Lob-Signature header(s)")
+	ErrNotTimestamped   = errors.New("no Lob-Signature-Timestamp header provided")
+	ErrNotSigned        = errors.New("no Lob-Signature header provided")
+	ErrNoValidSignature = errors.New("webhook has no valid signature")
+	ErrTooOld           = errors.New("timestamp wasn't within tolerance")
+)
+
+//ValidateWebhookPayload valides the passed in payload and signature header
+func ValidateWebhookPayload(payload []byte, timestampHeader, sigHeader, secret string, tolerance time.Duration) error {
+	if sigHeader == "" {
+		return ErrNotSigned
+	}
+
+	if err := hasValidTimestampWithTolerance(timestampHeader, tolerance); err != nil {
+		return err
+	}
+
+	sig, err := hex.DecodeString(sigHeader)
+	if err != nil {
+		return ErrInvalidHeader
+	}
+
+	computed := computeSignature(timestampHeader, payload, secret)
+
+	if hmac.Equal(computed, sig) {
+		return nil
+	}
+
+	return ErrNoValidSignature
+}
+
+func hasValidTimestampWithTolerance(timestampHeader string, tolerance time.Duration) error {
+	if timestampHeader == "" {
+		return ErrNotTimestamped
+	}
+
+	t, err := strconv.ParseInt(timestampHeader, 10, 64)
+	if err != nil {
+		return ErrInvalidHeader
+	}
+
+	if time.Since(time.Unix(t, 0)) > tolerance {
+		return ErrTooOld
+	}
+
+	return nil
+}
+
+func computeSignature(timestamp string, payload []byte, secret string) []byte {
+	mac := hmac.New(sha256.New, []byte(secret))
+
+	mac.Write([]byte(timestamp))
+	mac.Write([]byte("."))
+	mac.Write(payload)
+
+	return mac.Sum(nil)
+}

--- a/webhook.go
+++ b/webhook.go
@@ -52,7 +52,10 @@ func hasValidTimestampWithTolerance(timestampHeader string, tolerance time.Durat
 		return ErrInvalidHeader
 	}
 
-	if time.Since(time.Unix(t, 0)) > tolerance {
+	// lob.com sends the epoch time with milliseconds
+	sentTime := time.Unix(0, t*int64(time.Millisecond))
+
+	if time.Since(sentTime) > tolerance {
 		return ErrTooOld
 	}
 


### PR DESCRIPTION
- Added support for sending letters.
- Added some helpers `lob.String(value)` which creates a pointer
- When using a test key, only "fill in" the passed in components for address verification if it contains the "test" string back from Lob.com. I found when I was using one of their [test environment magic values](https://lob.com/docs#us-verification-test-environment) that their result was being overwrote by this package
- Updated the API version